### PR TITLE
code changes to read and write service id from and to xml file

### DIFF
--- a/src/java/com/mockey/model/UriTemplate.java
+++ b/src/java/com/mockey/model/UriTemplate.java
@@ -49,7 +49,7 @@ public class UriTemplate {
 	private static final Pattern NAMES_PATTERN = Pattern.compile("\\{([^/]+?)\\}");
 
 	/** Replaces template variables in the URI template. */
-	private static final String VALUE_REGEX = "\\{(.*?)\\}";
+	private static final String VALUE_REGEX = "(.*)";
 
 	private final List<String> variableNames;
 

--- a/src/java/com/mockey/storage/xml/MockeyXmlFileConfigurationGenerator.java
+++ b/src/java/com/mockey/storage/xml/MockeyXmlFileConfigurationGenerator.java
@@ -181,6 +181,11 @@ public class MockeyXmlFileConfigurationGenerator extends XmlGeneratorSupport {
 					getSafeForXmlOutputString(""
 							+ mockServiceBean.getDefaultRealUrlIndex()));
 
+			serviceElement.setAttribute(
+					"id",
+					getSafeForXmlOutputString(""
+							+ mockServiceBean.getId()));
+			
 			// Request validation rules in JSON format definition.
 			Element requestInspectorJsonRulesElement = document
 					.createElement("request_inspector_json_rules");

--- a/src/java/com/mockey/storage/xml/MockeyXmlFileConfigurationParser.java
+++ b/src/java/com/mockey/storage/xml/MockeyXmlFileConfigurationParser.java
@@ -143,6 +143,7 @@ public class MockeyXmlFileConfigurationParser {
 		fullSetDigester.addSetProperties(ROOT_SERVICE, "hang_time", "hangTime");
 		fullSetDigester.addSetProperties(ROOT_SERVICE, "url", "url");
 		fullSetDigester.addSetProperties(ROOT_SERVICE, "tag", "tag");
+		fullSetDigester.addSetProperties(ROOT_SERVICE, "id", "id");
 		// REMOVED March 2013.
 		// No need to persist to a repot'. At run time, visual queue only.
 		// fullSetDigester.addSetProperties(ROOT_SERVICE, "last_visit",

--- a/src/java/com/mockey/storage/xml/MockeyXmlFileManager.java
+++ b/src/java/com/mockey/storage/xml/MockeyXmlFileManager.java
@@ -400,7 +400,9 @@ public class MockeyXmlFileManager {
                 // YES, no in-store matching Name.
                 // We null ID, to not write-over on any in-store
                 // services with same ID
-                uploadedServiceBean.setId(null);
+                if(uploadedServiceBean.getId() == null) {
+                	uploadedServiceBean.setId(null);
+                }
 
                 // #TAG HANDLING - BEGIN
                 // Ensure Service, and all it's child scenarios have


### PR DESCRIPTION
The code in this PR helps in managing the ID for service definitions. The application will generate value for service id only If the <service> tag has no 'id' attribute in XML file. Otherwise the value for the given service id will be taken from XML file. By doing this we can have static/fixed service id for service definitions therefore Mockey server ensures service id does not change every time it is restarted. This capability helps other applications to send http request to Mockey server and change scenario for given service id.

I have created a issue to track this. https://github.com/clafonta/Mockey/issues/112

Please take a look at the code.